### PR TITLE
fix: clean up error messages if locale does not exist

### DIFF
--- a/src/usr/local/emhttp/plugins/file.activity/assets/translate.js
+++ b/src/usr/local/emhttp/plugins/file.activity/assets/translate.js
@@ -63,8 +63,20 @@ class Translator {
 
     let localeFlat = {};
     if (locale !== "en_US") {
-      const localeObj = await fetchJson(localePath);
-      localeFlat = Translator.flattenObject(localeObj);
+      // Get the list of locales from the server
+      const localesResponse = await fetch(`${this.basePath}/data.php/locales`);
+      if (localesResponse.ok) {
+        // Check if the current locale is in the list of available locales
+        let locales = await localesResponse.json();
+        locales = Object.values(locales);
+
+        if (locales.includes(locale)) {
+          const localeObj = await fetchJson(localePath);
+          localeFlat = Translator.flattenObject(localeObj);
+        } else {
+          console.warn(`Locale ${locale} not found in available locales.`);
+        }
+      }
     }
 
     // Merge: localeFlat overrides enUSFlat if key exists and is not blank

--- a/src/usr/local/emhttp/plugins/file.activity/data.php
+++ b/src/usr/local/emhttp/plugins/file.activity/data.php
@@ -27,6 +27,10 @@ require_once dirname(__FILE__) . "/include/common.php";
 
 $prefix = "/plugins/file.activity/data.php";
 
+if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PLUGIN_NAME')) {
+    throw new \RuntimeException("Common file not loaded.");
+}
+
 $app = AppFactory::create();
 $app->addRoutingMiddleware();
 $errorMiddleware = $app->addErrorMiddleware(true, true, true);
@@ -43,6 +47,26 @@ $app->get("{$prefix}/disk", function (Request $request, Response $response, $arg
     $payload  = json_encode($activity->flattenActivity($activity->getDiskActivity()), JSON_PRETTY_PRINT) ?: "{}";
     $response->getBody()->write($payload);
     return $response->withHeader('Content-Type', 'application/json');
+});
+
+$app->get("{$prefix}/locales", function (Request $request, Response $response, $args) {
+    // Get the list of supported locales from /locales (each locale is a JSON file)
+    $localesDir = PLUGIN_ROOT . '/locales';
+    $files      = scandir($localesDir);
+
+    foreach ($files as $key => $file) {
+        if ( ! is_file($localesDir . '/' . $file) || pathinfo($file, PATHINFO_EXTENSION) !== 'json') {
+            unset($files[$key]);
+        } else {
+            $files[$key] = basename($file, '.json'); // Store only the locale name without extension
+        }
+    }
+
+    $response->getBody()->write(json_encode($files) ?: "[]");
+    return $response
+        ->withHeader('Content-Type', 'application/json')
+        ->withHeader('Cache-Control', 'no-store')
+        ->withStatus(200);
 });
 
 $app->run();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamically fetching the list of available language locales from the server.
- **Bug Fixes**
  - Improved locale loading by verifying the availability of a locale before attempting to load its translation.
- **Chores**
  - Enhanced server-side checks to ensure required plugin definitions are present before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->