### PR TITLE
feat: add rollover setting

### DIFF
--- a/src/usr/local/emhttp/plugins/file.activity/include/Pages/Settings.php
+++ b/src/usr/local/emhttp/plugins/file.activity/include/Pages/Settings.php
@@ -3,7 +3,6 @@
 namespace EDACerton\FileActivity;
 
 use EDACerton\PluginUtils\Translator;
-use EDACerton\PluginUtils\Utils;
 
 /*
     Copyright (C) 2017-2025, Dan Landon
@@ -48,6 +47,8 @@ $(function() {
 <h3><?= $tr->tr("settings.monitoring"); ?></h3>
 
 <p><?= $tr->tr("settings.description"); ?></p>
+
+<p><?= $tr->tr("settings.re2"); ?>: <a href="https://github.com/google/re2/wiki/syntax" target="_blank"><?= $tr->tr("settings.reference"); ?></a></p>
 
 <p><?= $tr->tr("settings.note"); ?></p>
 
@@ -114,6 +115,16 @@ $(function() {
     </dl>
     <blockquote class="inline_help">
         <?= $tr->tr("settings.help.display_events"); ?>
+    </blockquote>
+
+    <dl>
+        <dt><?= $tr->tr("rollover"); ?></dt>
+        <dd>
+            <input type="number" name="max_records" min="1" step="1" class="narrow" value="<?= htmlspecialchars(strval($fileactivity_cfg->getMaxRecords()));?>" placeholder="20000"> <?= $tr->tr("current_usage"); ?>: <?= Utils::size_readable(Utils::getActivitySize()); ?>
+        </dd>
+    </dl>
+    <blockquote class="inline_help">
+        <?= $tr->tr("settings.help.rollover"); ?>
     </blockquote>
 
     <dl>

--- a/src/usr/local/emhttp/plugins/file.activity/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/file.activity/locales/en_US.json
@@ -31,10 +31,14 @@
     "remove": "Remove Exclusion",
     "save": "Save Settings",
     "exclusions": "Exclusions",
+    "rollover": "Rollover Threshold",
+    "current_usage": "Current Usage",
     "settings": {
         "monitoring": "File Activity Monitoring",
-        "description": "File open, read, write, and modify activity is monitored and logged on the array using inotify and is displayed by disk or share, UD disks, and cache. You need to start the File Activity in order to log the disk activity. File Activity is intended to be running for short periods so you can check disk activity. A server with a lot of file activity can fill the log space. The 'appdata', 'docker', 'syslogs', and 'system' directories (case insensitive) are excluded.",
+        "description": "File open, read, write, and modify activity is monitored and logged on the array using inotify and is displayed by disk or share, UD disks, and cache.",
         "note": "Note: File Activity monitoring is stopped if the array is stopped, and will restart when the array is started if it is enabled.",
+        "re2": "Exclusions use RE2 syntax",
+        "reference": "Reference",
         "apply_defaults": "Load and apply default values",
         "clear_data": "Clear data",
         "clear_data_description": "Erase the file activity log.",
@@ -43,7 +47,8 @@
             "enable_ssd": "Set to **Yes** to enable File Activity monitoring for any SSD Devices, otherwise only Spinning Devices are monitored. Monitoring SSD devices can overwhelm the server from hyper activity on SSDs.",
             "enable_unassigned": "Set to **Yes** to enable File Activity monitoring for Unassigned Devices if the Unassigned Devices plugin is installed.",
             "enable_cache": "Set to **Yes** to enable File Activity monitoring for the Cache and Pool Disks.",
-            "display_events": "This is the number of file events shown on disks and shares from the File Activity log for each share or disk."
+            "display_events": "This is the number of file events shown on disks and shares from the File Activity log for each share or disk.",
+            "rollover": "The number of file events to keep in the File Activity log before rolling over to a new log file. The current log file and one previous log file are kept."
         }
     }
 }

--- a/src/usr/local/php/unraid-fileactivity/unraid-fileactivity/Activity.php
+++ b/src/usr/local/php/unraid-fileactivity/unraid-fileactivity/Activity.php
@@ -2,8 +2,6 @@
 
 namespace EDACerton\FileActivity;
 
-use EDACerton\PluginUtils\Utils;
-
 /*
     Copyright (C) 2025  Derek Kaser
 

--- a/src/usr/local/php/unraid-fileactivity/unraid-fileactivity/Config.php
+++ b/src/usr/local/php/unraid-fileactivity/unraid-fileactivity/Config.php
@@ -2,8 +2,6 @@
 
 namespace EDACerton\FileActivity;
 
-use EDACerton\PluginUtils\Utils;
-
 /*
     Copyright (C) 2025  Derek Kaser
 

--- a/src/usr/local/php/unraid-fileactivity/unraid-fileactivity/Utils.php
+++ b/src/usr/local/php/unraid-fileactivity/unraid-fileactivity/Utils.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace EDACerton\FileActivity;
+
+/*
+    Copyright (C) 2025  Derek Kaser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+class Utils extends \EDACerton\PluginUtils\Utils
+{
+    public static function getActivitySize(): int
+    {
+        $size = 0;
+
+        $logFiles = [
+            "/var/log/file.activity/data.log",
+            "/var/log/file.activity/data.log.1"
+        ];
+
+        foreach ($logFiles as $file) {
+            if (file_exists($file)) {
+                $size += filesize($file);
+            }
+        }
+
+        return $size;
+    }
+
+    /**
+     * Return human readable sizes
+     *
+     * @author      Aidan Lister <aidan@php.net>
+     * @version     1.3.0
+     * @link        http://aidanlister.com/2004/04/human-readable-file-sizes/
+     * @param       int     $size        size in bytes
+     * @param       string  $max         maximum unit
+     * @param       string  $system      'si' for SI, 'bi' for binary prefixes
+     * @param       string  $retstring   return string format
+     */
+    public static function size_readable(int $size, ?string $max = null, string $system = 'si', string $retstring = '%01.2f %s'): string
+    {
+        // Pick units
+        $systems['si']['prefix'] = array('B', 'K', 'MB', 'GB', 'TB', 'PB');
+        $systems['si']['size']   = 1000;
+        $systems['bi']['prefix'] = array('B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB');
+        $systems['bi']['size']   = 1024;
+        $sys                     = isset($systems[$system]) ? $systems[$system] : $systems['si'];
+
+        // Max unit to display
+        $depth = count($sys['prefix']) - 1;
+        if ($max && false !== $d = array_search($max, $sys['prefix'])) {
+            $depth = $d;
+        }
+
+        // Loop
+        $i = 0;
+        while ($size >= $sys['size'] && $i < $depth) {
+            $size /= $sys['size'];
+            $i++;
+        }
+
+        return sprintf($retstring, $size, $sys['prefix'][$i]);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "rollover" setting in the File Activity plugin, allowing users to specify the maximum number of file events to retain before logs are rolled over.
  * Displayed the current usage of activity data in a human-readable format within the settings.

* **Documentation**
  * Updated and clarified help text and descriptions for monitoring, exclusions (now referencing RE2 syntax), and the new rollover setting in the plugin UI.

* **Bug Fixes**
  * Improved localization with new and updated UI strings for the new features and help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->