### PR TITLE
fix: style for Unraid 7.2

### DIFF
--- a/src/usr/local/emhttp/plugins/file.activity/assets/style.css
+++ b/src/usr/local/emhttp/plugins/file.activity/assets/style.css
@@ -29,10 +29,6 @@ div.flatpickr-calendar {
     font-size: 1.2rem;
 }
 
-div.dtcc-dropdown * {
-    color: black;
-}
-
 span.dtcc-button-icon svg {
     color: white;
     background-color: gray;
@@ -67,4 +63,8 @@ i.regex-error {
     margin-left: -18px;
     margin-right: 18px;
     display: none;
+}
+
+div.dt-length {
+    white-space: pre;
 }

--- a/src/usr/local/emhttp/plugins/file.activity/include/Pages/Settings.php
+++ b/src/usr/local/emhttp/plugins/file.activity/include/Pages/Settings.php
@@ -58,7 +58,7 @@ $(function() {
     <dl>
         <dt><?= $tr->tr("enable_monitoring"); ?></dt>
         <dd>
-            <select name="enable" size="1">
+            <select name="enable" size="1" class="narrow">
 		        <?= Utils::make_option( ! $fileactivity_cfg->isEnabled(), "no", $tr->tr("no"));?>
 		        <?= Utils::make_option($fileactivity_cfg->isEnabled(), "yes", $tr->tr("yes"));?>
 	        </select>
@@ -71,7 +71,7 @@ $(function() {
     <dl>
         <dt><?= $tr->tr("enable_ssd"); ?></dt>
         <dd>
-            <select name="ssd" size="1">
+            <select name="ssd" size="1" class="narrow">
 		        <?= Utils::make_option( ! $fileactivity_cfg->isSSDEnabled(), "no", $tr->tr("no"));?>
 		        <?= Utils::make_option($fileactivity_cfg->isSSDEnabled(), "yes", $tr->tr("yes"));?>
 	        </select>
@@ -84,7 +84,7 @@ $(function() {
     <dl>
         <dt><?= $tr->tr("enable_unassigned"); ?></dt>
         <dd>
-            <select name="unassigned_devices" size="1">
+            <select name="unassigned_devices" size="1" class="narrow">
                 <?= Utils::make_option($fileactivity_cfg->isUnassignedDevicesEnabled(), "yes", $tr->tr("yes"));?>
                 <?= Utils::make_option( ! $fileactivity_cfg->isUnassignedDevicesEnabled(), "no", $tr->tr("no"));?>
             </select>
@@ -97,7 +97,7 @@ $(function() {
     <dl>
         <dt><?= $tr->tr("enable_cache"); ?></dt>
         <dd>
-            <select name="cache" size="1">
+            <select name="cache" size="1" class="narrow">
                 <?= Utils::make_option( ! $fileactivity_cfg->isCacheEnabled(), "no", $tr->tr("no"));?>
                 <?= Utils::make_option($fileactivity_cfg->isCacheEnabled(), "yes", $tr->tr("yes"));?>
             </select>
@@ -129,7 +129,7 @@ $(function() {
 
     <dl>
         <dt><?= $tr->tr("exclusions"); ?></dt>
-        <dd><button type="button" id="add-exclusion" class="exclusion-button" onclick="addExclusion()"><?= $tr->tr("add"); ?></button></dd>
+        <dd><span><button type="button" id="add-exclusion" class="exclusion-button" onclick="addExclusion()"><?= $tr->tr("add"); ?></button></span></dd>
     </dl>
     <div id="exclusions-container">
         <?php foreach ($fileactivity_cfg->getExclusions() as $exclusion) { ?>
@@ -137,7 +137,7 @@ $(function() {
             <dd>
                 <input type="text" name="exclusions[]" oninput="validateRE2(this)" value="<?= htmlspecialchars($exclusion); ?>">
                 <i class="fa fa-exclamation-circle regex-error"></i>
-                <button type="button" class="exclusion-button" onclick="removeExclusion(this)"><?= $tr->tr("remove"); ?></button>
+                <span><button type="button" class="exclusion-button" onclick="removeExclusion(this)"><?= $tr->tr("remove"); ?></button></span>
             </dd></dl>
         <?php } ?>
     </div>
@@ -150,7 +150,7 @@ $(function() {
                                        <dd>
                                            <input type="text" oninput="validateRE2(this)" name="exclusions[]" value="">
                                            <i class="fa fa-exclamation-circle regex-error"></i>
-                                           <button type="button" class="exclusion-button" onclick="removeExclusion(this)"><?= $tr->tr("remove"); ?></button>
+                                           <span><button type="button" class="exclusion-button" onclick="removeExclusion(this)"><?= $tr->tr("remove"); ?></button></span>
                                        </dd>`;
             container.appendChild(newExclusion);
             formChanged();
@@ -190,7 +190,7 @@ $(function() {
     <dl>
         <dt><strong><?= $tr->tr("save"); ?></strong></dt>
         <dd>
-            <input type="submit" id="apply" value="<?= $tr->tr("apply"); ?>"><input type="button" value="<?= $tr->tr("done"); ?>" onclick="done()">
+            <span><input type="submit" id="apply" value="<?= $tr->tr("apply"); ?>"><input type="button" value="<?= $tr->tr("done"); ?>" onclick="done()"></span>
         </dd>
     </dl>
 </form>
@@ -199,7 +199,7 @@ $(function() {
 <dl>
     <dt><strong><?= $tr->tr("settings.apply_defaults"); ?></strong></dt>
     <dd>
-        <input type="submit" value="<?= $tr->tr("default"); ?>">
+        <span><input type="submit" value="<?= $tr->tr("default"); ?>"></span>
     </dd>
 </dl>
 </form>
@@ -210,7 +210,7 @@ $(function() {
 <dl>
     <dt><strong><?= $tr->tr("settings.clear_data_description"); ?></strong></dt>
     <dd>
-        <input type="submit" value="<?= $tr->tr('settings.clear_data'); ?>">
+        <span><input type="submit" value="<?= $tr->tr('settings.clear_data'); ?>"></span>
     </dd>
 </dl>
 </form>

--- a/src/usr/local/emhttp/plugins/file.activity/include/Pages/ShareActivity.php
+++ b/src/usr/local/emhttp/plugins/file.activity/include/Pages/ShareActivity.php
@@ -30,6 +30,11 @@ if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PL
 
 $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
+// Fix for black theme in Unraid 7.1 and earlier
+$vars = parse_ini_file('/usr/local/emhttp/state/var.ini');
+if (version_compare($vars['version'] ?? "", '7.1', '<=')) {
+    echo "<style>div.dtcc-dropdown * { color: black }</style>";
+}
 ?>
 <link type="text/css" rel="stylesheet" href="/plugins/file.activity/assets/style.css">
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a styling issue with dropdown text color in dark themes for Unraid versions 7.1 and earlier.
  * Fixed a CSS syntax error related to error highlighting.

* **Style**
  * Improved whitespace handling for specific display elements.
  * Updated form controls for a more consistent and compact appearance by adjusting select element styles and wrapping buttons in spans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->