### PR TITLE
fix: make event scripts use JSON config

### DIFF
--- a/src/usr/local/emhttp/plugins/file.activity/event/disks_mounted
+++ b/src/usr/local/emhttp/plugins/file.activity/event/disks_mounted
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
 # Read in the configuration.
-plugin="file.activity"
-CONFIG="/boot/config/plugins/${plugin}/${plugin}.cfg"
-source $CONFIG
+CONFIG="/boot/config/plugins/file.activity/config.json"
 
 # Start file activity if it is enabled.
-if [ "$SERVICE" = "enable" ]; then
-	/usr/local/emhttp/plugins/${plugin}/scripts/rc.${plugin} start
+if [ "$(jq -r '.enable' "$CONFIG" 2>/dev/null)" = "true" ]; then
+	/usr/local/emhttp/plugins/file.activity/scripts/rc.file.activity start 1>/dev/null
 fi

--- a/src/usr/local/emhttp/plugins/file.activity/event/started
+++ b/src/usr/local/emhttp/plugins/file.activity/event/started
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
 # Read in the configuration.
-plugin="file.activity"
-CONFIG="/boot/config/plugins/${plugin}/${plugin}.cfg"
-source $CONFIG
+CONFIG="/boot/config/plugins/file.activity/config.json"
 
 # Start file activity if it is enabled.
-if [ "$SERVICE" = "enable" ]; then
-	/usr/local/emhttp/plugins/${plugin}/scripts/rc.${plugin} start 1>/dev/null
+if [ "$(jq -r '.enable' "$CONFIG" 2>/dev/null)" = "true" ]; then
+	/usr/local/emhttp/plugins/file.activity/scripts/rc.file.activity start 1>/dev/null
 fi

--- a/src/usr/local/emhttp/plugins/file.activity/event/stopping_svcs
+++ b/src/usr/local/emhttp/plugins/file.activity/event/stopping_svcs
@@ -1,6 +1,3 @@
 #!/bin/bash
 
-# Stop file activity logging if it is running.
-if [ -e "/var/run/file.activity.pid" ]; then
-	/usr/local/emhttp/plugins/file.activity/scripts/rc.file.activity stop
-fi
+/usr/local/emhttp/plugins/file.activity/scripts/rc.file.activity stop

--- a/src/usr/local/emhttp/plugins/file.activity/event/stopping_svcs
+++ b/src/usr/local/emhttp/plugins/file.activity/event/stopping_svcs
@@ -1,8 +1,6 @@
 #!/bin/bash
-#
-plugin="file.activity"
 
 # Stop file activity logging if it is running.
-if [ -e "/var/run/${plugin}.pid" ]; then
-	/usr/local/emhttp/plugins/${plugin}/scripts/rc.${plugin} stop
+if [ -e "/var/run/file.activity.pid" ]; then
+	/usr/local/emhttp/plugins/file.activity/scripts/rc.file.activity stop
 fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * File activity plugin configuration now uses JSON format instead of the previous configuration method.
  * Updated event scripts to use hardcoded paths for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->